### PR TITLE
NO MRG: Test CircleCI fast finish fallback

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,17 +3,7 @@ general:
     ignore:
       - /.*/
 
-machine:
-  services:
-    - docker
-
-dependencies:
-  # Note, we used to use the naive caching of docker images, but found that it was quicker
-  # just to pull each time. #rollondockercaching
-  override:
-    - docker pull condaforge/linux-anvil
-
 test:
   override:
-    # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-    - ./ci_support/run_docker_build.sh
+    # In case the skip fails for some reason, do a fast finish.
+    - exit 0

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,9 @@
-general:
-  branches:
-    ignore:
-      - /.*/
+# Commenting so that we can demonstrate this works as expected.
+#
+#general:
+#  branches:
+#    ignore:
+#      - /.*/
 
 test:
   override:


### PR DESCRIPTION
Please do not merge this PR. It is for demonstration purposes only.

This PR tests out a re-rendering created by a development version of `conda-smithy` using PR ( https://github.com/conda-forge/conda-smithy/pull/242 ). The purpose of this change is to provide a passing fast finish fallback for CircleCI in the event it for some reason ignore the skip condition added in `circle.yml`. In this PR, we will start with the re-rendering and then remove the skip condition to demonstrate that this fast condition works correctly.

I have take the liberty of skipping AppVeyor here as that does not factor into our testing. Also running AppVeyor may make existing download issues ( https://github.com/Anaconda-Platform/support/issues/49 ) that we are currently experiencing worse. This would hurt other builds and distract from our purpose here.

cc @pelson